### PR TITLE
Fix a couple issues

### DIFF
--- a/lib/Open/unzip.js
+++ b/lib/Open/unzip.js
@@ -106,7 +106,9 @@ module.exports = function unzip(source,offset,_password, directoryVars) {
         .on('error',function(err) { entry.emit('error',err);})
         .pipe(entry)
         .on('finish', function() {
-          if (req.abort)
+          if (req.end)
+            req.end();
+          else if (req.abort)
             req.abort();
           else if (req.close)
             req.close();

--- a/lib/Open/unzip.js
+++ b/lib/Open/unzip.js
@@ -16,7 +16,9 @@ module.exports = function unzip(source,offset,_password, directoryVars) {
   var file = PullStream(),
       entry = Stream.PassThrough();
 
-  var req = source.stream(offset);
+  var EOF_LEN = 4;
+  var FIXED_HEADER_LEN = 30;
+  var req = source.stream(offset, directoryVars.compressedSize ? directoryVars.compressedSize + directoryVars.fileNameLength + directoryVars.extraFieldLength + EOF_LEN + FIXED_HEADER_LEN : undefined);
   req.pipe(file).on('error', function(e) {
     entry.emit('error', e);
   });


### PR DESCRIPTION
- Call `.end()` on stream after extraction for a file has finished
- Pass a populated `length` parameter to `stream` when extracting an entry